### PR TITLE
Add TCP connection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pyMeCom
 A python interface for the MeCom protocol by Meerstetter.
-This package was developed to control several TEC devices on a raspberry pi by connecting them via usb.
+This package was developed to control several TEC devices on a raspberry pi by connecting them via usb or via tcp.
 
 ## Requirements
 1. this code is only tested in Python 3 running in a linux OS

--- a/example.py
+++ b/example.py
@@ -4,7 +4,7 @@
 import logging
 import platform
 from time import time, sleep
-from mecom import MeCom, ResponseException, WrongChecksum
+from mecom import MeComSerial, ResponseException, WrongChecksum
 from serial import SerialException
 from serial.serialutil import PortNotOpenError
 
@@ -52,7 +52,7 @@ class MeerstetterTEC(object):
     def _connect(self):
         # open session
         if self.port is not None:
-            self._session = MeCom(serialport=self.port)
+            self._session = MeComSerial(serialport=self.port)
         else:
             if platform.system() != "Windows":
                 start_index = 0
@@ -65,7 +65,7 @@ class MeerstetterTEC(object):
             while True:
                 for i in range(start_index, MAX_COM + 1):
                     try:
-                        self._session = MeCom(serialport=base_name + str(i))
+                        self._session = MeComSerial(serialport=base_name + str(i))
                         break
                     except SerialException:
                         pass

--- a/example_LDD.py
+++ b/example_LDD.py
@@ -2,7 +2,7 @@
 
 """
 import logging
-from mecom import MeCom, ResponseException, WrongChecksum
+from mecom import MeComSerial, ResponseException, WrongChecksum
 from serial import SerialException
 
 
@@ -40,7 +40,7 @@ class MeerstetterLDD(object):
 
     def _connect(self):
         # open session
-        self._session = MeCom(serialport=self.port,metype = 'LDD')
+        self._session = MeComSerial(serialport=self.port,metype = 'LDD')
         # get device address
         self.address = self._session.identify()
         logging.info("connected to {}".format(self.address))

--- a/mecom/__init__.py
+++ b/mecom/__init__.py
@@ -7,5 +7,5 @@ mecom.py contains the communication logic
 
 """
 
-from .mecom import MeCom, VR, VS, Parameter
+from .mecom import MeCom, MeComSerial, MeComTcp, VR, VS, Parameter
 from .exceptions import ResponseException, WrongChecksum


### PR DESCRIPTION
This branch adds support for establishing TCP (Ethernet) connections with Meerstetter devices. It is implemented within a `MeComTcp` class, and the `MeCom` class is renamed to `MeComSerial` while keeping it accessible under the old name for backwards compatibility.
Code independent of transport protocols is now located in the `MeComCommon` class.

The splitting up into separate classes allows developers to decide which transport protocol to use and makes adding more transport protocols in the future easier. However, if this does not fit into the general architectural design of the interface, other solutions could also be considered.