### PR TITLE
Added ability to directly run get and set commands from the commandline

### DIFF
--- a/mecom/mecom.py
+++ b/mecom/mecom.py
@@ -1024,10 +1024,11 @@ class MeCom(MeComSerial):
 
 if __name__ == "__main__":
     import argparse
-    import re
 
     def setParamStr(mc, paramStr):
-        m=re.match("\s*(.*?)\s*=\s*(.*?)\s*$", paramStr)
+        m=paramStr.split('=', 1)
+        varStr=m[0].strip()
+        valStr=m[1].strip()
         varStr=m.group(1)
         valStr=m.group(2)
         pl=ParameterList()


### PR DESCRIPTION
Hi,

Many thanks for the pyMeCom meersetter  python module!
It works really well, and saved me a lot of time.

To make it easier to start using the get and set commands, I've added argparse command line parameter processing:

#get Object Temperature and Target Object temperature:
python3 -m mecom.mecom -g 'Object Temperature,Target Object Temperature'

#set Target Object Temperature to 24C:
python3 -m mecom.mecom -s 'Target Object Temperature=24'