### PR TITLE
Added: LATIN1/?VB commands; --get cmdarg now is list; several commands.py TEC commands

### DIFF
--- a/mecom/commands.py
+++ b/mecom/commands.py
@@ -6,24 +6,49 @@ Documents can be found at https://www.meerstetter.ch/customer-center/downloads/c
 #common TEC family parameters
 #for a full list of parameters and their description, see the "TEC-Family MeCom Communication Protocol" document
 TEC_PARAMETERS = [
+    {"id": 100, "name": "Device Type", "format": "INT32"},
+    {"id": 101, "name": "Hardware Version", "format": "INT32"},
+    {"id": 103, "name": "Firmware Version", "format": "INT32"},
     {"id": 104, "name": "Device Status", "format": "INT32"},
     {"id": 105, "name": "Error Number", "format": "INT32"},
+    {"id": 106, "name": "Error Instance", "format": "INT32"},
+    {"id": 107, "name": "Error Parameter", "format": "INT32"},
+    {"id": 109, "name": "Parameter System: Flash Status", "format": "INT32"},
     {"id": 108, "name": "Save Data to Flash", "format": "INT32"},
     {"id": 109, "name": "Flash Status", "format": "INT32"},
+    {"id": 110, "name": "Error Text", "format": "LATIN1"},
+    {"id": 111, "name": "Device Reset", "format": "INT32"},
 
     {"id": 1000, "name": "Object Temperature", "format": "FLOAT32"},
     {"id": 1001, "name": "Sink Temperature", "format": "FLOAT32"},
-    {"id": 3000, "name": "Target Object Temperature", "format": "FLOAT32"},
     {"id": 1011, "name": "Ramp Object Temperature", "format": "FLOAT32"},
     {"id": 1020, "name": "Actual Output Current", "format": "FLOAT32"},
     {"id": 1021, "name": "Actual Output Voltage", "format": "FLOAT32"},
+
+    #The names for these values differs from that in TEC Con Com Protocol 5136AR,
+    #as the name 'Resistance' also appears in 3040.
+    {"id": 1040, "name": "HR ADC Raw Value", "format": "FLOAT32"},
+    {"id": 1041, "name": "LR ADC Raw Value", "format": "FLOAT32"},
+    {"id": 1042, "name": "HR ADC Resistance", "format": "FLOAT32"},
+    {"id": 1043, "name": "LR ADC Resistance", "format": "FLOAT32"},
+    {"id": 1046, "name": "HR ADC Differential Voltage", "format": "FLOAT32"},
+
+
+    {"id": 1051, "name": "Firmware Build Number", "format": "INT32"},
+    {"id": 1054, "name": "Min Version for Firmware Downgrade", "format": "INT32"},
+
+
+    {"id": 1065, "name": "Unique ID", "format": "LATIN1"},
+    {"id": 1060, "name": "Driver Input Voltage", "format": "FLOAT32"},
+    {"id": 1061, "name": "Medium Internal Supply", "format": "FLOAT32"},
+    {"id": 1071, "name": "Actual Output Limit", "format": "FLOAT32"},
+    {"id": 1073, "name": "Final Output Limitation", "format": "FLOAT32"},
+
     {"id": 1102, "name": "Actual Fan Speed", "format": "FLOAT32"},
+    {"id": 1111, "name": "Maximum Output Current", "format": "FLOAT32"},
+
+
     {"id": 1200, "name": "Temperature is Stable", "format": "INT32"},
-    {"id": 3002, "name": "Proximity Width", "format": "FLOAT32"},
-    {"id": 3003, "name": "Coarse Temp Ramp", "format": "FLOAT32"},
-    {"id": 3010, "name": "Kp", "format": "FLOAT32"},
-    {"id": 3011, "name": "Ti", "format": "FLOAT32"},
-    {"id": 3012, "name": "Td", "format": "FLOAT32"},
 
     {"id": 2000, "name": "Output Stage Input Selection", "format": "INT32"},
     {"id": 2010, "name": "Output Enable Status", "format": "INT32"},
@@ -33,7 +58,39 @@ TEC_PARAMETERS = [
     {"id": 2031, "name": "Voltage Limitation", "format": "FLOAT32"},
     {"id": 2032, "name": "Current Error Threshold", "format": "FLOAT32"},
     {"id": 2033, "name": "Voltage Error Threshold", "format": "FLOAT32"},
+    {"id": 2040, "name": "General Operating Mode", "format": "INT32"},
     {"id": 2051, "name": "Device Address", "format": "INT32"},
+
+    {"id": 3000, "name": "Target Object Temperature", "format": "FLOAT32"},
+    {"id": 3002, "name": "Proximity Width", "format": "FLOAT32"},
+    {"id": 3003, "name": "Coarse Temp Ramp", "format": "FLOAT32"},
+    {"id": 3010, "name": "Kp", "format": "FLOAT32"},
+    {"id": 3011, "name": "Ti", "format": "FLOAT32"},
+    {"id": 3012, "name": "Td", "format": "FLOAT32"},
+    {"id": 3013, "name": "D Part Damping PT1", "format": "FLOAT32"},
+    {"id": 3020, "name": "Mode", "format": "INT32"},
+    {"id": 3034, "name": "Polarity", "format": "INT32"},
+
+    #The name 'Resistor' appears twice in 5136AR (also for 1042) -so added 'Load'
+    {"id": 3040, "name": "Load Resistance", "format": "FLOAT32"},
+    {"id": 3041, "name": "Maximum Current", "format": "FLOAT32"},
+
+    {"id": 3050, "name": "Lower Boundary", "format": "FLOAT32"},
+    {"id": 3051, "name": "Upper Boundary", "format": "FLOAT32"},
+
+    {"id": 4034, "name": "Sensor Type", "format": "INT32"},
+
+    {"id": 6000, "name": "PGA Gain", "format": "INT32"},
+    {"id": 6007, "name": "PGA Bypass", "format": "INT32"},
+    {"id": 6001, "name": "ADC Current Source", "format": "INT32"},
+    {"id": 6008, "name": "ADC Current Source 2 Out", "format": "INT32"},
+    {"id": 6009, "name": "Measurement Type", "format": "INT32"},
+    {"id": 6002, "name": "ADC Rs", "format": "FLOAT32"},
+    {"id": 6006, "name": "ADC Rp", "format": "FLOAT32"},
+    {"id": 6020, "name": "Display Type", "format": "INT32"},
+    {"id": 6021, "name": "Periodic Display Re-Init", "format": "INT32"},
+    {"id": 6023, "name": "Display Line 1-4 Alternative Mode", "format": "INT32"},
+
 
     {"id": 6100, "name": "GPIO Function", "format": "INT32"},
     {"id": 6101, "name": "GPIO Level Assignment", "format": "INT32"},
@@ -45,7 +102,9 @@ TEC_PARAMETERS = [
     {"id": 6221, "name": "Fan 100 Speed", "format": "INT32"},
 
     {"id": 6300, "name": "Object Source Selection", "format": "INT32"},
+    {"id": 6301, "name": "Sampling Frequency", "format": "INT32"},
     {"id": 6302, "name": "Observe Mode", "format": "INT32"},
+    {"id": 6304, "name": "Sink Source Selection", "format": "INT32"},
     {"id": 6310, "name": "Delay till Restart", "format": "FLOAT32"},
     {"id": 52100, "name": "Enable Function", "format": "INT32"},
     {"id": 52101, "name": "Set Output to Push-Pull", "format": "INT32"},

--- a/mecom/mecom.py
+++ b/mecom/mecom.py
@@ -1110,9 +1110,9 @@ if __name__ == "__main__":
             except ValueError:
                 try:
                 parameter=pl.get_by_name(vs)
-            except UnknownParameter as inst:
-                print(f'UnknownParameter: "{vs}"')
-                return
+                except UnknownParameter:
+                    print(f'Unknown parameter: "{vs}"')
+                    return None
             val=mc.get_parameter(parameter_id=parameter.id, *args, **kwargs)
             print(f'{parameter.id:4d}: {parameter.name:20s} = {val}')
 

--- a/mecom/mecom.py
+++ b/mecom/mecom.py
@@ -259,8 +259,8 @@ class Query(MeFrame):
         else:
             if self.dataformat == 'LATIN1':
                 self.RESPONSE = VBResponse(self._RESPONSE_FORMAT)
-        else:
-            self.RESPONSE = VRResponse(self._RESPONSE_FORMAT)
+            else:
+                self.RESPONSE = VRResponse(self._RESPONSE_FORMAT)
             # if the checksum is wrong, this statement raises
             self.RESPONSE.decompose(response_frame)
 
@@ -273,7 +273,7 @@ class EmptyResponse(MeFrame):
     """
     No response.
     """
-    
+
     def __init__(self):
         """
         Creates an instance of an empty response.
@@ -352,7 +352,7 @@ class VS(Query):
         # cast the value parameter to the correct type
         conversions = {'FLOAT32': float, 'INT32': int}
         assert parameter.format in conversions.keys()
-        
+
         value=conversions[parameter.format](value)
 
         # the set value
@@ -372,7 +372,7 @@ class RS(Query):
         :param address: int
         :param parameter_instance: int
         """
-        
+
         # init header
         super(RS, self).__init__(parameter=None, address=address)
 
@@ -407,7 +407,7 @@ class IF(Query):
         :param address: int
         :param parameter_instance: int
         """
-        
+
         # init header (equal for get and set queries)
         super(IF, self).__init__(parameter=None,
                          address=address,
@@ -481,7 +481,7 @@ class ACK(MeFrame):
     ACK command sent by the device.
     """
     _SOURCE = "!"
-    
+
     def decompose(self, frame_bytes):
         """
         Takes bytes as input and builds the instance.
@@ -490,10 +490,10 @@ class ACK(MeFrame):
         """
         frame_bytes = self._SOURCE.encode() + frame_bytes
         self._decompose_header(frame_bytes)
-        
+
         frame = frame_bytes.decode()
         self.CRC = int(frame[-4:], 16)
-        
+
 
 class IFResponse(MeFrame):
     """
@@ -624,7 +624,7 @@ class MeComCommon:
 
     def _inc(self):
         self.SEQUENCE_COUNTER += 1
-        # sequence in controller is int16 and overflows 
+        # sequence in controller is int16 and overflows
         self.SEQUENCE_COUNTER = self.SEQUENCE_COUNTER % (2**16)
 
     @staticmethod
@@ -657,9 +657,9 @@ class MeComCommon:
             vb = self._execute(VB(parameter=parameter, start_position=0, max_nread=1023, *args, **kwargs))
             return vb
         else:
-        # execute query
-        vr = self._execute(VR(parameter=parameter, *args, **kwargs))
-        return vr
+            # execute query
+            vr = self._execute(VR(parameter=parameter, *args, **kwargs))
+            return vr
 
     def _get_raw(self, parameter_id, parameter_format, *args, **kwargs):
         """
@@ -767,7 +767,7 @@ class MeComCommon:
         # check if value setting has succeeded
         #
         # Not necessary as we get an acknowledge response or Value is out of range
-        # exception when an invalid value was passed. 
+        # exception when an invalid value was passed.
         # current implementation also often fails due to rounding, e.g. setting 1.0
         # but returning 0.999755859375 when performing a self.get_parameter
         # value_set = self.get_parameter(parameter_id=parameter_id, parameter_name=parameter_name, *args, **kwargs)
@@ -792,21 +792,21 @@ class MeComCommon:
         # check if value setting has succeeded
         #
         # Not necessary as we get an acknowledge response or Value is out of range
-        # exception when an invalid value was passed. 
+        # exception when an invalid value was passed.
         # current implementation also often fails due to rounding, e.g. setting 1.0
         # but returning 0.999755859375 when performing a self.get_parameter
         # value_set = self.get_parameter(parameter_id=parameter_id, parameter_name=parameter_name, *args, **kwargs)
 
         # return True if we got an ACK
         return type(vs.RESPONSE) == ACK
-    
+
     def reset_device(self,*args, **kwargs):
         """
         Resets the device after an error has occured
         """
         rs = self._execute(RS(*args, **kwargs))
         return type(rs.RESPONSE) == ACK
-    
+
     def info(self,*args, **kwargs):
         """
         Resets the device after an error has occured
@@ -849,7 +849,7 @@ class MeComCommon:
 
         # return address and status
         return status_name
-    
+
     # enable or disable auto saving to flash
     enable_autosave = partialmethod(set_parameter, value=0, parameter_name="Save Data to Flash")
     disable_autosave = partialmethod(set_parameter, value=1, parameter_name="Save Data to Flash")

--- a/mecom/mecom.py
+++ b/mecom/mecom.py
@@ -1108,6 +1108,7 @@ if __name__ == "__main__":
             try:
                 parameter=pl.get_by_id(int(vs))
             except ValueError:
+                try:
                 parameter=pl.get_by_name(vs)
             except UnknownParameter as inst:
                 print(f'UnknownParameter: "{vs}"')

--- a/mecom/mecom.py
+++ b/mecom/mecom.py
@@ -1109,7 +1109,7 @@ if __name__ == "__main__":
                 parameter=pl.get_by_id(int(vs))
             except ValueError:
                 try:
-                parameter=pl.get_by_name(vs)
+                    parameter=pl.get_by_name(vs)
                 except UnknownParameter:
                     print(f'Unknown parameter: "{vs}"')
                     return None


### PR DESCRIPTION
Hi,

For my setup I will really need to get the 'Unique ID' of the setup, so I implemented ?VB (LATIN1) format get commands. (For now, CRC doesn't work. seems like the type(p)==str case in MeFrame.compose is already used?)

Also, made the '--get' command a little bit nicer, it can now accept a list of MeParID's (both numerical and text). 

As I now have a TEC 1167, I needed to be able to access parameter_instance other than 1, so I added a --instance (and --address) commandline argument too.

Lastly, added several more TEC family commands.

So this is now possible:

```
$ python3 -m mecom.mecom --get 'Set Current,Object Temperature, Sink Temperature,Hardware Version,Firmware Version,Unique ID'

connected to device: 2, status: Ready
2020: Set Current          = -0.05000000074505806
1000: Object Temperature   = 21.966814041137695
1001: Sink Temperature     = 25.0
 101: Hardware Version     = 120
 103: Firmware Version     = 620
1065: Unique ID            = 2037-394E-5831-5003-0045-001F
```



